### PR TITLE
refactor: refactor Downloads according to TypographyStyles

### DIFF
--- a/client/src/components/home/Downloads.jsx
+++ b/client/src/components/home/Downloads.jsx
@@ -1,5 +1,8 @@
 import React from 'react'
 
+// Styled Components
+import { SecondaryHeading, Paragraph } from '../../styles/TypographyStyles'
+import { Container, SectionHeadingContainer } from '../../styles/LayoutStyles'
 import {
   DownloadsPosition,
   DownloadsSection,
@@ -8,34 +11,39 @@ import {
   DownloadButtonInnerFlex,
 } from '../../styles/home/DownloadsStyles'
 
+// Icons
 import { WhiteAppleIcon, PlaystoreIcon } from '../../assets/icons/icons'
 
 function Downloads() {
   return (
     <DownloadsSection>
-      <DownloadsPosition>
-        <h2>Download our app</h2>
-        <p>
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-          eiusmod tempor incididunt ut labore et dolore magna aliqua.
-        </p>
-        <GroupButtons>
-          <DownloadButton>
-            <WhiteAppleIcon />
-            <DownloadButtonInnerFlex>
-              <p>Download on the</p>
-              <p>App Store</p>
-            </DownloadButtonInnerFlex>
-          </DownloadButton>
-          <DownloadButton>
-            <PlaystoreIcon />
-            <DownloadButtonInnerFlex>
-              <p>GET IT ON</p>
-              <p>Google Play</p>
-            </DownloadButtonInnerFlex>
-          </DownloadButton>
-        </GroupButtons>
-      </DownloadsPosition>
+      <Container>
+        <DownloadsPosition>
+          <SectionHeadingContainer center>
+            <SecondaryHeading>Download our app</SecondaryHeading>
+            <Paragraph>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+              eiusmod tempor incididunt ut labore et dolore magna aliqua.
+            </Paragraph>
+          </SectionHeadingContainer>
+          <GroupButtons>
+            <DownloadButton>
+              <WhiteAppleIcon />
+              <DownloadButtonInnerFlex>
+                <p>Download on the</p>
+                <p>App Store</p>
+              </DownloadButtonInnerFlex>
+            </DownloadButton>
+            <DownloadButton>
+              <PlaystoreIcon />
+              <DownloadButtonInnerFlex>
+                <p>GET IT ON</p>
+                <p>Google Play</p>
+              </DownloadButtonInnerFlex>
+            </DownloadButton>
+          </GroupButtons>
+        </DownloadsPosition>
+      </Container>
     </DownloadsSection>
   )
 }

--- a/client/src/styles/home/DownloadsStyles.jsx
+++ b/client/src/styles/home/DownloadsStyles.jsx
@@ -1,23 +1,15 @@
 import tw, { styled } from 'twin.macro'
 
 export const DownloadsSection = styled.section`
-  ${tw`bg-bg2 py-24 px-10`}
+  ${tw`py-24 bg-bg2`}
 `
 
 export const DownloadsPosition = styled.div`
-  ${tw`mx-auto max-w-xl`}
-  // title
-  h2 {
-    ${tw`text-center`}
-  }
-  // sub-title
-  p:only-of-type {
-    ${tw`mx-auto my-8 w-[90%] text-center text-black`}
-  }
+  ${tw`max-w-xl mx-auto`}
 `
 
 export const GroupButtons = styled.div`
-  ${tw`mb-2 flex flex-col justify-center gap-12 pt-8 md:flex-row`}
+  ${tw`flex flex-col justify-center gap-12 pt-8 mb-2 md:flex-row`}
 `
 
 export const DownloadButton = styled.button`


### PR DESCRIPTION
I changed `h1`, `p` to `PrimaryHeading` and `Paragraph` styled components. Also wrapped inner content into `Container` layout styled component. It provides max width for extra big screens, centres content accordingly, adds left and right paddings for all screens. It can be reused in all sections, at least in the website part.